### PR TITLE
Inclusão de testes unitários e refactoring

### DIFF
--- a/Lanhellas.KafkaConsumerBatch.sln
+++ b/Lanhellas.KafkaConsumerBatch.sln
@@ -1,6 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lanhellas.KafkaConsumerBatch", "Lanhellas.KafkaConsumerBatch\Lanhellas.KafkaConsumerBatch.csproj", "{C6B53B59-80FE-49F4-A9EB-C2986734B628}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31229.75
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lanhellas.KafkaConsumerBatch", "Lanhellas.KafkaConsumerBatch\Lanhellas.KafkaConsumerBatch.csproj", "{C6B53B59-80FE-49F4-A9EB-C2986734B628}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lanhellas.KafkaConsumerBatchUnitTests", "Lanhellas.KafkaConsumerBatchUnitTests\Lanhellas.KafkaConsumerBatchUnitTests.csproj", "{C33661E7-9438-4C93-A6A0-7EC7A8BD83AF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,5 +17,15 @@ Global
 		{C6B53B59-80FE-49F4-A9EB-C2986734B628}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C6B53B59-80FE-49F4-A9EB-C2986734B628}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C6B53B59-80FE-49F4-A9EB-C2986734B628}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C33661E7-9438-4C93-A6A0-7EC7A8BD83AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C33661E7-9438-4C93-A6A0-7EC7A8BD83AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C33661E7-9438-4C93-A6A0-7EC7A8BD83AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C33661E7-9438-4C93-A6A0-7EC7A8BD83AF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3EA1B816-8C01-44C2-ACA2-0DDA426E7D0D}
 	EndGlobalSection
 EndGlobal

--- a/Lanhellas.KafkaConsumerBatch/IKafkaConsumerBatch.cs
+++ b/Lanhellas.KafkaConsumerBatch/IKafkaConsumerBatch.cs
@@ -1,0 +1,11 @@
+﻿using Confluent.Kafka;
+using System.Collections.Generic;
+
+namespace Lanhellas.KafkaConsumerBatch
+{
+    public interface IKafkaConsumerBatch<TKey, TValue>
+    {
+        IReadOnlyList<ConsumeResult<TKey, TValue>> ConsumeBatch();
+        void SeekBatch();
+    }
+}

--- a/Lanhellas.KafkaConsumerBatch/IKafkaConsumerBatch.cs
+++ b/Lanhellas.KafkaConsumerBatch/IKafkaConsumerBatch.cs
@@ -6,6 +6,6 @@ namespace Lanhellas.KafkaConsumerBatch
     public interface IKafkaConsumerBatch<TKey, TValue>
     {
         IReadOnlyList<ConsumeResult<TKey, TValue>> ConsumeBatch();
-        void SeekBatch();
+        IReadOnlyList<TopicPartitionOffset> SeekBatch();
     }
 }

--- a/Lanhellas.KafkaConsumerBatch/IKafkaConsumerBatchBuilder.cs
+++ b/Lanhellas.KafkaConsumerBatch/IKafkaConsumerBatchBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace Lanhellas.KafkaConsumerBatch
+{
+    public interface IKafkaConsumerBatchBuilder<TKey, TValue>
+    {
+        IKafkaConsumerBatch<TKey, TValue> Build();
+    }
+}

--- a/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatch.cs
+++ b/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatch.cs
@@ -17,7 +17,7 @@ namespace Lanhellas.KafkaConsumerBatch
 
         public KafkaConsumerBatch(IConsumer<TKey,TValue> consumer, int batchSize, TimeSpan maxWaitTime, ILogger logger)
         {
-            _records = new List<ConsumeResult<TKey, TValue>>();
+            _records = new List<ConsumeResult<TKey, TValue>>(batchSize);
             _batchSize = batchSize;
             _maxWaitTime = maxWaitTime;
             _consumer = consumer;

--- a/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatch.cs
+++ b/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatch.cs
@@ -52,7 +52,7 @@ namespace Lanhellas.KafkaConsumerBatch
             }
         }
 
-        private int StartConsume()
+        private void StartConsume()
         {
             List<ConsumeResult<TKey, TValue>> records = _records;
             var source = new CancellationTokenSource();
@@ -72,7 +72,6 @@ namespace Lanhellas.KafkaConsumerBatch
                     break;
                 }
             }
-            return records.Count;
         }
     }
 }

--- a/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatch.cs
+++ b/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatch.cs
@@ -10,10 +10,11 @@ namespace Lanhellas.KafkaConsumerBatch
     public class KafkaConsumerBatch<TKey, TValue> : IKafkaConsumerBatch<TKey, TValue>
     {
         private readonly List<ConsumeResult<TKey, TValue>> _records;
-        private readonly int _batchSize;
-        private readonly TimeSpan _maxWaitTime;
-        private readonly IConsumer<TKey, TValue> _consumer;
-        private readonly ILogger _logger;
+        
+        internal readonly int _batchSize;
+        internal readonly TimeSpan _maxWaitTime;
+        internal readonly IConsumer<TKey, TValue> _consumer;
+        internal readonly ILogger _logger;
 
         public KafkaConsumerBatch(IConsumer<TKey, TValue> consumer, int batchSize, TimeSpan maxWaitTime, ILogger logger)
         {

--- a/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatchBuilder.cs
+++ b/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatchBuilder.cs
@@ -1,46 +1,50 @@
-using System;
 using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Lanhellas.KafkaConsumerBatch
 {
-    public class KafkaConsumerBatchBuilder<TKey,TValue>
+    public class KafkaConsumerBatchBuilder<TKey, TValue> : IKafkaConsumerBatchBuilder<TKey, TValue>
     {
         private IConsumer<TKey, TValue> _consumer;
         private int _batchSize;
         private TimeSpan _maxWaitTime;
         private ILogger _logger;
 
-        public static KafkaConsumerBatchBuilder<TKey,TValue> Config()
+        
+        private KafkaConsumerBatchBuilder()
+        { }
+
+        public static KafkaConsumerBatchBuilder<TKey, TValue> Config()
         {
             return new KafkaConsumerBatchBuilder<TKey, TValue>();
         }
-        
-        public KafkaConsumerBatchBuilder<TKey,TValue> WithConsumer(IConsumer<TKey, TValue> consumer)
+
+        public KafkaConsumerBatchBuilder<TKey, TValue> WithConsumer(IConsumer<TKey, TValue> consumer)
         {
             _consumer = consumer;
             return this;
         }
-        
-        public KafkaConsumerBatchBuilder<TKey,TValue> WithBatchSize(int batchSize)
+
+        public KafkaConsumerBatchBuilder<TKey, TValue> WithBatchSize(int batchSize)
         {
             _batchSize = batchSize;
             return this;
         }
-        
-        public KafkaConsumerBatchBuilder<TKey,TValue> WithMaxWaitTime(TimeSpan maxWaitTime)
+
+        public KafkaConsumerBatchBuilder<TKey, TValue> WithMaxWaitTime(TimeSpan maxWaitTime)
         {
             _maxWaitTime = maxWaitTime;
             return this;
         }
-        
-        public KafkaConsumerBatchBuilder<TKey,TValue> WithLogger(ILogger logger)
+
+        public KafkaConsumerBatchBuilder<TKey, TValue> WithLogger(ILogger logger)
         {
             _logger = logger;
             return this;
-        } 
+        }
 
-        public KafkaConsumerBatch<TKey, TValue> Build()
+        public IKafkaConsumerBatch<TKey, TValue> Build()
         {
             return new KafkaConsumerBatch<TKey, TValue>(_consumer, _batchSize, _maxWaitTime, _logger);
         }

--- a/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatchBuilder.cs
+++ b/Lanhellas.KafkaConsumerBatch/KafkaConsumerBatchBuilder.cs
@@ -13,7 +13,8 @@ namespace Lanhellas.KafkaConsumerBatch
 
         
         private KafkaConsumerBatchBuilder()
-        { }
+        { 
+        }
 
         public static KafkaConsumerBatchBuilder<TKey, TValue> Config()
         {

--- a/Lanhellas.KafkaConsumerBatch/Lanhellas.KafkaConsumerBatch.csproj
+++ b/Lanhellas.KafkaConsumerBatch/Lanhellas.KafkaConsumerBatch.csproj
@@ -18,5 +18,9 @@
         <PackageReference Include="Confluent.Kafka" Version="1.6.3" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     </ItemGroup>
-
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+        <_Parameter1>Lanhellas.KafkaConsumerBatchUnitTests</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
 </Project>

--- a/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchBuilderUnitTests.cs
+++ b/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchBuilderUnitTests.cs
@@ -66,5 +66,17 @@ namespace Lanhellas.KafkaConsumerBatchUnitTests
 
             Assert.Same(expectedLogger, consumer._logger);
         }
+
+        [Fact]
+        public void Build_WithMultipleSets_ShouldConsiderLastValue()
+        {
+            int expectedBatchSize = 133;
+            var consumer = KafkaConsumerBatchBuilder<string, string>.Config()
+                .WithBatchSize(199)
+                .WithBatchSize(expectedBatchSize)
+                .Build() as KafkaConsumerBatch<string, string>;
+
+            Assert.Equal(expectedBatchSize, consumer._batchSize);
+        }
     }
 }

--- a/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchBuilderUnitTests.cs
+++ b/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchBuilderUnitTests.cs
@@ -1,0 +1,70 @@
+﻿using Confluent.Kafka;
+using Lanhellas.KafkaConsumerBatch;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Lanhellas.KafkaConsumerBatchUnitTests
+{
+    public class KafkaConsumerBatchBuilderUnitTests
+    {
+        [Fact]
+        public void Build_WithNoConfig_ShouldHaveDefaultValues()
+        {
+            var consumer = KafkaConsumerBatchBuilder<string, string>.Config()
+                .Build() as KafkaConsumerBatch<string, string>;
+
+            Assert.Null(consumer._consumer);
+            Assert.Null(consumer._logger);
+            Assert.Equal(0, consumer._batchSize);
+            Assert.Equal(TimeSpan.Zero, consumer._maxWaitTime);
+        }
+
+        [Fact]
+        public void Build_WithBatchSize_ShouldConfigureWithDefinedValue()
+        {
+            int expectedBatchSize = 133;
+            var consumer = KafkaConsumerBatchBuilder<string, string>.Config()
+                .WithBatchSize(expectedBatchSize)
+                .Build() as KafkaConsumerBatch<string, string>;
+
+            Assert.Equal(expectedBatchSize, consumer._batchSize);
+        }
+
+        [Fact]
+        public void Build_WithMaxWaitTime_ShouldConfigureWithDefinedValue()
+        {
+            TimeSpan expectedMaxWaitTime = TimeSpan.FromMilliseconds(133);
+            var consumer = KafkaConsumerBatchBuilder<string, string>.Config()
+                .WithMaxWaitTime(expectedMaxWaitTime)
+                .Build() as KafkaConsumerBatch<string, string>;
+
+            Assert.Equal(expectedMaxWaitTime, consumer._maxWaitTime);
+        }
+
+        [Fact]
+        public void Build_WithConsumer_ShouldConfigureWithDefinedValue()
+        {
+            IConsumer<string, string> expectedConsumer = new Mock<IConsumer<string, string>>().Object;
+            var consumer = KafkaConsumerBatchBuilder<string, string>.Config()
+                .WithConsumer(expectedConsumer)
+                .Build() as KafkaConsumerBatch<string, string>;
+
+            Assert.Same(expectedConsumer, consumer._consumer);
+        }
+
+        [Fact]
+        public void Build_WithLogger_ShouldConfigureWithDefinedValue()
+        {
+            ILogger expectedLogger = new Mock<ILogger>().Object;
+            var consumer = KafkaConsumerBatchBuilder<string, string>.Config()
+                .WithLogger(expectedLogger)
+                .Build() as KafkaConsumerBatch<string, string>;
+
+            Assert.Same(expectedLogger, consumer._logger);
+        }
+    }
+}

--- a/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchUnitTests.cs
+++ b/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchUnitTests.cs
@@ -36,16 +36,15 @@ namespace Lanhellas.KafkaConsumerBatchUnitTests
             Assert.Empty(consumerBatch.ConsumeBatch());
         }
 
-        // should be true?
-        //[Fact]
-        //public void ConsumeBatch_WhenElapsedWaitTimeWithOneResult_ShouldReturnOneItem()
-        //{
-        //    mockConsumer.Setup(t => t.Consume(It.IsAny<TimeSpan>()))
-        //        .Callback(() => Thread.Sleep(maxWaitTime))
-        //        .Returns(new ConsumeResult<string, string>());
+        [Fact]
+        public void ConsumeBatch_WhenElapsedWaitTimeWithOneResult_ShouldReturnOneItem()
+        {
+            mockConsumer.Setup(t => t.Consume(It.IsAny<TimeSpan>()))
+                .Callback(() => Thread.Sleep(maxWaitTime))
+                .Returns(new ConsumeResult<string, string>());
 
-        //    Assert.Single(consumerBatch.ConsumeBatch());
-        //}
+            Assert.Single(consumerBatch.ConsumeBatch());
+        }
 
         [Fact]
         public void ConsumeBatch_WhenElapsedWaitTimeWithBatchSize_ShouldReturnCollectionWithBatchSize()

--- a/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchUnitTests.cs
+++ b/Lanhellas.KafkaConsumerBatchUnitTests/KafkaConsumerBatchUnitTests.cs
@@ -1,0 +1,61 @@
+using Confluent.Kafka;
+using Lanhellas.KafkaConsumerBatch;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Lanhellas.KafkaConsumerBatchUnitTests
+{
+    public class KafkaConsumerBatchUnitTests
+    {
+        private readonly Mock<IConsumer<string, string>> mockConsumer;
+        private readonly KafkaConsumerBatch<string, string> consumerBatch;
+        private readonly int batchSize;
+        private readonly TimeSpan maxWaitTime;
+
+        public KafkaConsumerBatchUnitTests()
+        {
+            batchSize = 10;
+            maxWaitTime = TimeSpan.FromMilliseconds(100);
+            mockConsumer = new Mock<IConsumer<string, string>>();
+            consumerBatch = new KafkaConsumerBatch<string, string>(mockConsumer.Object,
+                batchSize, maxWaitTime, NullLogger.Instance);
+        }
+
+        [Fact]
+        public void ConsumeBatch_WhenElapsedWaitTimeWithNoResults_ShouldReturnEmptyCollection()
+        {
+            mockConsumer.Setup(t => t.Consume(It.IsAny<TimeSpan>()))
+                .Callback(() => Thread.Sleep(maxWaitTime))
+                .Returns((ConsumeResult<string, string>)null);
+
+            Assert.Empty(consumerBatch.ConsumeBatch());
+        }
+
+        // should be true?
+        //[Fact]
+        //public void ConsumeBatch_WhenElapsedWaitTimeWithOneResult_ShouldReturnOneItem()
+        //{
+        //    mockConsumer.Setup(t => t.Consume(It.IsAny<TimeSpan>()))
+        //        .Callback(() => Thread.Sleep(maxWaitTime))
+        //        .Returns(new ConsumeResult<string, string>());
+
+        //    Assert.Single(consumerBatch.ConsumeBatch());
+        //}
+
+        [Fact]
+        public void ConsumeBatch_WhenElapsedWaitTimeWithBatchSize_ShouldReturnCollectionWithBatchSize()
+        {
+            mockConsumer.Setup(t => t.Consume(It.IsAny<TimeSpan>()))
+                .Returns(new ConsumeResult<string, string>());
+
+            Assert.Equal(batchSize, consumerBatch.ConsumeBatch().Count());
+        }
+
+
+    }
+}

--- a/Lanhellas.KafkaConsumerBatchUnitTests/Lanhellas.KafkaConsumerBatchUnitTests.csproj
+++ b/Lanhellas.KafkaConsumerBatchUnitTests/Lanhellas.KafkaConsumerBatchUnitTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lanhellas.KafkaConsumerBatch\Lanhellas.KafkaConsumerBatch.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
* Incluídas interfaces para facilitar criação de testes unitários para código cliente;
* Refatoração na inicialização do list interno para reduzir possíveis realocações;
* Alteração de SeekBatch para retornar List<TopicPartitionOffset>;
* Alteração de comportamento no StartConsume onde passou a utilizar absolute wait time ao invés de rolling wait time;